### PR TITLE
Fixed issue where Chaplet audio would not play in the background on iOS.

### DIFF
--- a/App_Resources/iOS/Info.plist
+++ b/App_Resources/iOS/Info.plist
@@ -48,5 +48,9 @@
 		<string>tel</string>
 		<string>telprompt</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Divine Mercy App
+
+### `nativescript-audio` and background audio
+By default, `nativescript-audio` (used for playing the chaplet audio) tells iOS that the sound is "ambient" (i.e. unimportant). This causes the audio to stop when the app is put into the background. To resolve this issue, we either need to fork `nativescript-audio` or apply the following change manually after every update of that dependency.
+
+1. Open `node_modules/nativescript-audio/ios/player.js`
+2. Replace all occurrences of `AVAudioSessionCategoryAmbient` with `AVAudioSessionCategoryPlayAndRecord`.


### PR DESCRIPTION
This commit along with the `nativescript-audio` workaround described in README.md allows the Chaplet to continue playing after the device is locked or the app is minimized.

The dependency workaround needs to be automated to prevent regression, but since @rchisholm has more experience with `npm` he should decide the best course of action. Please note that the simulator does not pause ambient audio when the app enters the background, so testing needs to include physical devices.